### PR TITLE
Make internal XML parser more tolerant

### DIFF
--- a/src/compression/gzip.rs
+++ b/src/compression/gzip.rs
@@ -15,16 +15,16 @@ use types::Result;
 /// Decode (decompress) the input using GZip.
 pub fn decode(input: &[u8]) -> Result<Vec<u8>> {
     let mut output = Vec::new();
-    let mut decoder = try!(GzDecoder::new(input));
-    try!(decoder.read_to_end(&mut output));
+    let mut decoder = GzDecoder::new(input)?;
+    decoder.read_to_end(&mut output)?;
     Ok(output)
 }
 
 /// Encode (compress) the input using GZip.
 pub fn encode(input: &[u8]) -> Result<Vec<u8>> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::Default);
-    try!(encoder.write_all(input));
-    let output = try!(encoder.finish());
+    encoder.write_all(input)?;
+    let output = encoder.finish()?;
     Ok(output)
 }
 

--- a/src/crypto/aes256.rs
+++ b/src/crypto/aes256.rs
@@ -20,7 +20,7 @@ pub fn decrypt(key: &MasterKey, iv: &MasterIV, input: &[u8]) -> Result<Vec<u8>> 
     let mut write_buffer = RefWriteBuffer::new(&mut buffer);
 
     loop {
-        let result = try!(cipher.decrypt(&mut read_buffer, &mut write_buffer, true));
+        let result = cipher.decrypt(&mut read_buffer, &mut write_buffer, true)?;
         output.extend(
             write_buffer
                 .take_read_buffer()
@@ -46,7 +46,7 @@ pub fn encrypt(key: &MasterKey, iv: &MasterIV, input: &[u8]) -> Result<Vec<u8>> 
     let mut write_buffer = RefWriteBuffer::new(&mut buffer);
 
     loop {
-        let result = try!(cipher.encrypt(&mut read_buffer, &mut write_buffer, true));
+        let result = cipher.encrypt(&mut read_buffer, &mut write_buffer, true)?;
         output.extend(
             write_buffer
                 .take_read_buffer()

--- a/src/crypto/random_gen.rs
+++ b/src/crypto/random_gen.rs
@@ -16,7 +16,7 @@ pub struct RandomGen(OsRng);
 impl RandomGen {
     /// Attempts to create a new random number generator.
     pub fn new() -> Result<RandomGen> {
-        let os_rng = try!(OsRng::new());
+        let os_rng = OsRng::new()?;
         Ok(RandomGen(os_rng))
     }
 

--- a/src/format/kdb2_reader.rs
+++ b/src/format/kdb2_reader.rs
@@ -42,7 +42,7 @@ pub fn read<R>(reader: &mut R, composite_key: &CompositeKey) -> Result<(MetaData
 where
     R: Log + Read,
 {
-    let version = try!(read_version(reader));
+    let version = read_version(reader)?;
     let mut comment: Option<Comment> = None;
     let mut compression: Option<Compression> = None;
     let mut master_cipher: Option<MasterCipher> = None;
@@ -55,51 +55,51 @@ where
     let mut transform_seed: Option<TransformSeed> = None;
 
     loop {
-        let header_id = try!(reader.read_u8());
+        let header_id = reader.read_u8()?;
         match header_id {
             kdb2::COMMENT_HID => {
-                comment = Some(try!(read_comment(reader)));
+                comment = Some(read_comment(reader)?);
             }
 
             kdb2::COMPRESSION_HID => {
-                compression = Some(try!(read_compression(reader)));
+                compression = Some(read_compression(reader)?);
             }
 
             kdb2::END_HID => {
-                try!(read_end_header(reader));
+                read_end_header(reader)?;
                 break;
             }
 
             kdb2::MASTER_CIPHER_HID => {
-                master_cipher = Some(try!(read_master_cipher(reader)));
+                master_cipher = Some(read_master_cipher(reader)?);
             }
 
             kdb2::MASTER_IV_HID => {
-                master_iv = Some(try!(read_master_iv(reader)));
+                master_iv = Some(read_master_iv(reader)?);
             }
 
             kdb2::MASTER_SEED_HID => {
-                master_seed = Some(try!(read_master_seed(reader)));
+                master_seed = Some(read_master_seed(reader)?);
             }
 
             kdb2::PROTECTED_STREAM_KEY_HID => {
-                protected_stream_key = Some(try!(read_protected_stream_key(reader)));
+                protected_stream_key = Some(read_protected_stream_key(reader)?);
             }
 
             kdb2::STREAM_CIPHER_HID => {
-                stream_cipher = Some(try!(read_stream_cipher(reader)));
+                stream_cipher = Some(read_stream_cipher(reader)?);
             }
 
             kdb2::STREAM_START_BYTES_HID => {
-                stream_start_bytes = Some(try!(read_stream_start_bytes(reader)));
+                stream_start_bytes = Some(read_stream_start_bytes(reader)?);
             }
 
             kdb2::TRANSFORM_ROUNDS_HID => {
-                transform_rounds = Some(try!(read_transform_rounds(reader)));
+                transform_rounds = Some(read_transform_rounds(reader)?);
             }
 
             kdb2::TRANSFORM_SEED_HID => {
-                transform_seed = Some(try!(read_transform_seed(reader)));
+                transform_seed = Some(read_transform_seed(reader)?);
             }
 
             _ => return Err(Error::UnhandledHeader(header_id)),
@@ -110,30 +110,30 @@ where
     reader.stop();
     reader.clear();
 
-    let compression = try!(get_header(compression, kdb2::COMPRESSION_HID));
-    let master_cipher = try!(get_header(master_cipher, kdb2::MASTER_CIPHER_HID));
-    let master_iv = try!(get_header(master_iv, kdb2::MASTER_IV_HID));
-    let master_seed = try!(get_header(master_seed, kdb2::MASTER_SEED_HID));
+    let compression = get_header(compression, kdb2::COMPRESSION_HID)?;
+    let master_cipher = get_header(master_cipher, kdb2::MASTER_CIPHER_HID)?;
+    let master_iv = get_header(master_iv, kdb2::MASTER_IV_HID)?;
+    let master_seed = get_header(master_seed, kdb2::MASTER_SEED_HID)?;
     let protected_stream_key =
-        try!(get_header(protected_stream_key, kdb2::PROTECTED_STREAM_KEY_HID));
-    let stream_cipher = try!(get_header(stream_cipher, kdb2::STREAM_CIPHER_HID));
-    let stream_start_bytes = try!(get_header(stream_start_bytes, kdb2::STREAM_START_BYTES_HID));
-    let transform_rounds = try!(get_header(transform_rounds, kdb2::TRANSFORM_ROUNDS_HID));
-    let transform_seed = try!(get_header(transform_seed, kdb2::TRANSFORM_SEED_HID));
+        get_header(protected_stream_key, kdb2::PROTECTED_STREAM_KEY_HID)?;
+    let stream_cipher = get_header(stream_cipher, kdb2::STREAM_CIPHER_HID)?;
+    let stream_start_bytes = get_header(stream_start_bytes, kdb2::STREAM_START_BYTES_HID)?;
+    let transform_rounds = get_header(transform_rounds, kdb2::TRANSFORM_ROUNDS_HID)?;
+    let transform_seed = get_header(transform_seed, kdb2::TRANSFORM_SEED_HID)?;
 
     let transformed_key = TransformedKey::new(&composite_key, &transform_seed, &transform_rounds);
     let master_key = MasterKey::new(&master_seed, &transformed_key);
     let stream_key = StreamKey::new(&protected_stream_key);
 
-    let encrypted = try!(read_enc_payload(reader));
-    let payload = try!(aes256::decrypt(&master_key, &master_iv, &encrypted));
+    let encrypted = read_enc_payload(reader)?;
+    let payload = aes256::decrypt(&master_key, &master_iv, &encrypted)?;
 
     if payload[0..32] != stream_start_bytes.0 {
         return Err(Error::InvalidKey);
     }
 
-    let xml_bytes = try!(read_xml_bytes(&compression, &payload[32..]));
-    let xml_data = try!(kdb2_xml_reader::read(&mut Cursor::new(xml_bytes), &stream_key));
+    let xml_bytes = read_xml_bytes(&compression, &payload[32..])?;
+    let xml_data = kdb2_xml_reader::read(&mut Cursor::new(xml_bytes), &stream_key)?;
     let meta_data = MetaData {
         comment: comment,
         compression: compression,
@@ -148,15 +148,15 @@ where
 }
 
 fn read_comment<R: Read>(reader: &mut R) -> Result<Comment> {
-    let size = try!(reader.read_u16::<LittleEndian>()) as usize;
-    let data = try!(read_bytes_size(reader, &size));
+    let size = reader.read_u16::<LittleEndian>()? as usize;
+    let data = read_bytes_size(reader, &size)?;
     Ok(Comment(data))
 }
 
 fn read_compression<R: Read>(reader: &mut R) -> Result<Compression> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::COMPRESSION_SIZE {
-        let data = try!(reader.read_u32::<LittleEndian>());
+        let data = reader.read_u32::<LittleEndian>()?;
         match data {
             0 => Ok(Compression::None),
             1 => Ok(Compression::GZip),
@@ -172,21 +172,21 @@ fn read_compression<R: Read>(reader: &mut R) -> Result<Compression> {
 }
 
 fn read_end_header<R: Read>(reader: &mut R) -> Result<()> {
-    let size = try!(reader.read_u16::<LittleEndian>()) as usize;
-    try!(read_bytes_size(reader, &size));
+    let size = reader.read_u16::<LittleEndian>()? as usize;
+    read_bytes_size(reader, &size)?;
     Ok(())
 }
 
 fn read_enc_payload<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
     let mut data = Vec::new();
-    try!(reader.read_to_end(&mut data));
+    reader.read_to_end(&mut data)?;
     Ok(data)
 }
 
 fn read_master_cipher<R: Read>(reader: &mut R) -> Result<MasterCipher> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::MASTER_CIPHER_SIZE {
-        let data = try!(read_bytes_16(reader));
+        let data = read_bytes_16(reader)?;
         if data == &kdb2::AES_CIPHER_ID[..] {
             Ok(MasterCipher::Aes256)
         } else {
@@ -202,9 +202,9 @@ fn read_master_cipher<R: Read>(reader: &mut R) -> Result<MasterCipher> {
 }
 
 fn read_master_iv<R: Read>(reader: &mut R) -> Result<MasterIV> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::MASTER_IV_SIZE {
-        let data = try!(read_bytes_16(reader));
+        let data = read_bytes_16(reader)?;
         Ok(MasterIV(data))
     } else {
         Err(Error::InvalidHeaderSize {
@@ -216,9 +216,9 @@ fn read_master_iv<R: Read>(reader: &mut R) -> Result<MasterIV> {
 }
 
 fn read_master_seed<R: Read>(reader: &mut R) -> Result<MasterSeed> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::MASTER_SEED_SIZE {
-        let data = try!(read_bytes_32(reader));
+        let data = read_bytes_32(reader)?;
         Ok(MasterSeed(data))
     } else {
         Err(Error::InvalidHeaderSize {
@@ -230,9 +230,9 @@ fn read_master_seed<R: Read>(reader: &mut R) -> Result<MasterSeed> {
 }
 
 fn read_protected_stream_key<R: Read>(reader: &mut R) -> Result<ProtectedStreamKey> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::PROTECTED_STREAM_KEY_SIZE {
-        let data = try!(read_bytes_32(reader));
+        let data = read_bytes_32(reader)?;
         Ok(ProtectedStreamKey(data))
     } else {
         Err(Error::InvalidHeaderSize {
@@ -244,9 +244,9 @@ fn read_protected_stream_key<R: Read>(reader: &mut R) -> Result<ProtectedStreamK
 }
 
 fn read_stream_cipher<R: Read>(reader: &mut R) -> Result<StreamCipher> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::STREAM_CIPHER_SIZE {
-        let data = try!(reader.read_u32::<LittleEndian>());
+        let data = reader.read_u32::<LittleEndian>()?;
         match data {
             2 => Ok(StreamCipher::Salsa20),
             _ => Err(Error::UnhandledStreamCipher(data)),
@@ -261,9 +261,9 @@ fn read_stream_cipher<R: Read>(reader: &mut R) -> Result<StreamCipher> {
 }
 
 fn read_stream_start_bytes<R: Read>(reader: &mut R) -> Result<StreamStartBytes> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::STREAM_START_BYTES_SIZE {
-        let data = try!(read_bytes_32(reader));
+        let data = read_bytes_32(reader)?;
         Ok(StreamStartBytes(data))
     } else {
         Err(Error::InvalidHeaderSize {
@@ -275,9 +275,9 @@ fn read_stream_start_bytes<R: Read>(reader: &mut R) -> Result<StreamStartBytes> 
 }
 
 fn read_transform_rounds<R: Read>(reader: &mut R) -> Result<TransformRounds> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::TRANSFORM_ROUNDS_SIZE {
-        let data = try!(reader.read_u64::<LittleEndian>());
+        let data = reader.read_u64::<LittleEndian>()?;
         Ok(TransformRounds(data))
     } else {
         Err(Error::InvalidHeaderSize {
@@ -289,9 +289,9 @@ fn read_transform_rounds<R: Read>(reader: &mut R) -> Result<TransformRounds> {
 }
 
 fn read_transform_seed<R: Read>(reader: &mut R) -> Result<TransformSeed> {
-    let size = try!(reader.read_u16::<LittleEndian>());
+    let size = reader.read_u16::<LittleEndian>()?;
     if size == kdb2::TRANSFORM_SEED_SIZE {
-        let data = try!(read_bytes_32(reader));
+        let data = read_bytes_32(reader)?;
         Ok(TransformSeed(data))
     } else {
         Err(Error::InvalidHeaderSize {
@@ -303,8 +303,8 @@ fn read_transform_seed<R: Read>(reader: &mut R) -> Result<TransformSeed> {
 }
 
 fn read_version<R: Read>(reader: &mut R) -> Result<Version> {
-    let minor = try!(reader.read_u16::<LittleEndian>());
-    let major = try!(reader.read_u16::<LittleEndian>());
+    let minor = reader.read_u16::<LittleEndian>()?;
+    let major = reader.read_u16::<LittleEndian>()?;
     Ok(Version {
         major: major,
         minor: minor,
@@ -316,10 +316,10 @@ fn read_xml_bytes(compression: &Compression, payload: &[u8]) -> Result<Vec<u8>> 
     let mut xml = Vec::new();
 
     for block_id in 0..u32::max_value() {
-        let id = try!(reader.read_u32::<LittleEndian>());
-        let hash = try!(read_bytes_32(&mut reader));
-        let size = try!(reader.read_u32::<LittleEndian>()) as usize;
-        let raw_data = try!(read_bytes_size(&mut reader, &size));
+        let id = reader.read_u32::<LittleEndian>()?;
+        let hash = read_bytes_32(&mut reader)?;
+        let size = reader.read_u32::<LittleEndian>()? as usize;
+        let raw_data = read_bytes_size(&mut reader, &size)?;
 
         if id != block_id {
             return Err(Error::InvalidBlockId(id));
@@ -338,7 +338,7 @@ fn read_xml_bytes(compression: &Compression, payload: &[u8]) -> Result<Vec<u8>> 
             return Err(Error::InvalidBlockHash);
         }
 
-        let mut block_data = try!(decompress(compression, &raw_data));
+        let mut block_data = decompress(compression, &raw_data)?;
         xml.append(&mut block_data);
 
     }
@@ -348,19 +348,19 @@ fn read_xml_bytes(compression: &Compression, payload: &[u8]) -> Result<Vec<u8>> 
 
 fn read_bytes_16<R: Read>(reader: &mut R) -> Result<[u8; 16]> {
     let mut data = [0; 16];
-    try!(reader.read(&mut data));
+    reader.read(&mut data)?;
     Ok(data)
 }
 
 fn read_bytes_32<R: Read>(reader: &mut R) -> Result<[u8; 32]> {
     let mut data = [0; 32];
-    try!(reader.read(&mut data));
+    reader.read(&mut data)?;
     Ok(data)
 }
 
 fn read_bytes_size<R: Read>(reader: &mut R, size: &usize) -> Result<Vec<u8>> {
     let mut data = vec![0; *size];
-    try!(reader.read(&mut data));
+    reader.read(&mut data)?;
     Ok(data)
 }
 

--- a/src/format/kdb2_xml_reader.rs
+++ b/src/format/kdb2_xml_reader.rs
@@ -40,12 +40,12 @@ pub fn read<R: Read>(reader: &mut R, stream_key: &StreamKey) -> Result<XmlData> 
     let mut reader = EventReader::new(reader);
     let mut cipher = salsa20::new_cipher(stream_key);
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::KEE_PASS_FILE_TAG => {
-                        try!(read_kee_pass_file(&mut reader, &mut data, &mut cipher));
+                        read_kee_pass_file(&mut reader, &mut data, &mut cipher)?;
                     }
                     _ => return xml::read_err(&mut reader, "Invalid root node"),
                 }
@@ -68,15 +68,15 @@ fn read_kee_pass_file<R: Read>(
     cipher: &mut Salsa20,
 ) -> Result<()> {
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::META_TAG => {
-                        try!(read_meta(reader, data));
+                        read_meta(reader, data)?;
                     }
                     kdb2::ROOT_TAG => {
-                        try!(read_root(reader, data, cipher));
+                        read_root(reader, data, cipher)?;
                     }
                     _ => {}
                 }
@@ -97,87 +97,87 @@ fn read_kee_pass_file<R: Read>(
 
 fn read_meta<R: Read>(reader: &mut EventReader<R>, data: &mut XmlData) -> Result<()> {
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::BINARIES_TAG => {
-                        data.binaries = try!(read_binaries(reader));
+                        data.binaries = read_binaries(reader)?;
                     }
                     kdb2::COLOR_TAG => {
-                        data.color = try!(xml::read_color_opt(reader));
+                        data.color = xml::read_color_opt(reader)?;
                     }
                     kdb2::CUSTOM_DATA_TAG => {
-                        data.custom_data = try!(read_custom_data(reader));
+                        data.custom_data = read_custom_data(reader)?;
                     }
                     kdb2::CUSTOM_ICONS_TAG => {
-                        data.custom_icons = try!(read_custom_icons(reader));
+                        data.custom_icons = read_custom_icons(reader)?;
                     }
                     kdb2::DATABASE_DESCRIPTION_TAG => {
-                        data.description = try!(xml::read_string(reader));
+                        data.description = xml::read_string(reader)?;
                     }
                     kdb2::DATABASE_DESCRIPTION_CHANGED_TAG => {
-                        data.description_changed = try!(xml::read_datetime(reader));
+                        data.description_changed = xml::read_datetime(reader)?;
                     }
                     kdb2::DATABASE_NAME_TAG => {
-                        data.name = try!(xml::read_string(reader));
+                        data.name = xml::read_string(reader)?;
                     }
                     kdb2::DATABASE_NAME_CHANGED_TAG => {
-                        data.name_changed = try!(xml::read_datetime(reader));
+                        data.name_changed = xml::read_datetime(reader)?;
                     }
                     kdb2::DEFAULT_USERNAME_TAG => {
-                        data.def_username = try!(xml::read_string(reader));
+                        data.def_username = xml::read_string(reader)?;
                     }
                     kdb2::DEFAULT_USERNAME_CHANGED_TAG => {
-                        data.def_username_changed = try!(xml::read_datetime(reader));
+                        data.def_username_changed = xml::read_datetime(reader)?;
                     }
                     kdb2::ENTRY_TEMPLATES_GROUP_TAG => {
-                        data.entry_templates_group_uuid = GroupUuid(try!(xml::read_uuid(reader)));
+                        data.entry_templates_group_uuid = GroupUuid(xml::read_uuid(reader)?);
                     }
                     kdb2::ENTRY_TEMPLATES_GROUP_CHANGED_TAG => {
-                        data.entry_templates_group_changed = try!(xml::read_datetime(reader));
+                        data.entry_templates_group_changed = xml::read_datetime(reader)?;
                     }
                     kdb2::GENERATOR_TAG => {
-                        data.generator = try!(xml::read_string(reader));
+                        data.generator = xml::read_string(reader)?;
                     }
                     kdb2::HEADER_HASH_TAG => {
-                        data.header_hash = Some(HeaderHash(try!(xml::read_binary(reader))));
+                        data.header_hash = Some(HeaderHash(xml::read_binary(reader)?));
                     }
                     kdb2::HISTORY_MAX_ITEMS_TAG => {
-                        data.history_max_items = try!(xml::read_i32(reader));
+                        data.history_max_items = xml::read_i32(reader)?;
                     }
                     kdb2::HISTORY_MAX_SIZE_TAG => {
-                        data.history_max_size = try!(xml::read_i32(reader));
+                        data.history_max_size = xml::read_i32(reader)?;
                     }
                     kdb2::LAST_SELECTED_GROUP_TAG => {
-                        data.last_selected_group = GroupUuid(try!(xml::read_uuid(reader)));
+                        data.last_selected_group = GroupUuid(xml::read_uuid(reader)?);
                     }
                     kdb2::LAST_TOP_VISIBLE_GROUP_TAG => {
-                        data.last_top_visible_group = GroupUuid(try!(xml::read_uuid(reader)));
+                        data.last_top_visible_group = GroupUuid(xml::read_uuid(reader)?);
                     }
                     kdb2::MAINTENANCE_HISTORY_DAYS_TAG => {
-                        data.maintenance_history_days = try!(xml::read_i32(reader));
+                        data.maintenance_history_days = xml::read_i32(reader)?;
                     }
                     kdb2::MASTER_KEY_CHANGE_FORCE_TAG => {
-                        data.master_key_change_force = try!(xml::read_i32(reader));
+                        data.master_key_change_force = xml::read_i32(reader)?;
                     }
                     kdb2::MASTER_KEY_CHANGE_REC_TAG => {
-                        data.master_key_change_rec = try!(xml::read_i32(reader));
+                        data.master_key_change_rec = xml::read_i32(reader)?;
                     }
                     kdb2::MASTER_KEY_CHANGED_TAG => {
-                        data.master_key_changed = try!(xml::read_datetime(reader));
+                        data.master_key_changed = xml::read_datetime(reader)?;
                     }
                     kdb2::MEMORY_PROTECTION_TAG => {
-                        try!(read_memory_protection(reader, data));
+                        read_memory_protection(reader, data)?;
                     }
                     kdb2::RECYCLE_BIN_CHANGED_TAG => {
-                        data.recycle_bin_changed = try!(xml::read_datetime(reader));
+                        data.recycle_bin_changed = xml::read_datetime(reader)?;
                     }
                     kdb2::RECYCLE_BIN_ENABLED_TAG => {
-                        data.recycle_bin_enabled = try!(xml::read_bool(reader));
+                        data.recycle_bin_enabled = xml::read_bool(reader)?;
                     }
                     kdb2::RECYCLE_BIN_UUID_TAG => {
-                        data.recycle_bin_uuid = GroupUuid(try!(xml::read_uuid(reader)));
+                        data.recycle_bin_uuid = GroupUuid(xml::read_uuid(reader)?);
                     }
                     _ => {}
                 }
@@ -202,12 +202,12 @@ fn read_root<R: Read>(
     cipher: &mut Salsa20,
 ) -> Result<()> {
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::GROUP_TAG => {
-                        data.root_group = Some(try!(read_group(reader, cipher)));
+                        data.root_group = Some(read_group(reader, cipher)?);
                     }
                     _ => {}
                 }
@@ -229,17 +229,17 @@ fn read_root<R: Read>(
 fn read_binaries<R: Read>(reader: &mut EventReader<R>) -> Result<BinariesMap> {
     let mut map = BinariesMap::new();
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, attributes, .. } => {
                 match name.local_name.as_str() {
                     kdb2::BINARY_TAG => {
-                        let id = BinaryId(try!(get_id_attr_value(reader, &attributes)));
-                        let compressed = try!(get_compressed_attr_value(reader, &attributes));
+                        let id = BinaryId(get_id_attr_value(reader, &attributes)?);
+                        let compressed = get_compressed_attr_value(reader, &attributes)?;
                         let bytes = if compressed {
-                            try!(xml::read_gzip(reader))
+                            xml::read_gzip(reader)?
                         } else {
-                            try!(xml::read_binary(reader))
+                            xml::read_binary(reader)?
                         };
                         map.insert(id, bytes);
                     }
@@ -263,12 +263,12 @@ fn read_binaries<R: Read>(reader: &mut EventReader<R>) -> Result<BinariesMap> {
 fn read_custom_data<R: Read>(reader: &mut EventReader<R>) -> Result<CustomDataMap> {
     let mut map = CustomDataMap::new();
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::ITEM_TAG => {
-                        let (key, value) = try!(read_custom_data_item(reader));
+                        let (key, value) = read_custom_data_item(reader)?;
                         map.insert(key, value);
                     }
                     _ => {}
@@ -292,15 +292,15 @@ fn read_custom_data_item<R: Read>(reader: &mut EventReader<R>) -> Result<(String
     let mut key: Option<String> = None;
     let mut value: Option<String> = None;
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::KEY_TAG => {
-                        key = try!(xml::read_string_opt(reader));
+                        key = xml::read_string_opt(reader)?;
                     }
                     kdb2::VALUE_TAG => {
-                        value = try!(xml::read_string_opt(reader));
+                        value = xml::read_string_opt(reader)?;
                     }
                     _ => {}
                 }
@@ -332,12 +332,12 @@ fn read_custom_data_item<R: Read>(reader: &mut EventReader<R>) -> Result<(String
 fn read_custom_icons<R: Read>(reader: &mut EventReader<R>) -> Result<CustomIconsMap> {
     let mut map = CustomIconsMap::new();
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::ICON_TAG => {
-                        let (uuid, data) = try!(read_custom_icon(reader));
+                        let (uuid, data) = read_custom_icon(reader)?;
                         map.insert(uuid, data);
                     }
                     _ => {}
@@ -361,15 +361,15 @@ fn read_custom_icon<R: Read>(reader: &mut EventReader<R>) -> Result<(CustomIconU
     let mut uuid: Option<CustomIconUuid> = None;
     let mut data: Option<Vec<u8>> = None;
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::DATA_TAG => {
-                        data = try!(xml::read_binary_opt(reader));
+                        data = xml::read_binary_opt(reader)?;
                     }
                     kdb2::UUID_TAG => {
-                        uuid = try!(xml::read_custom_icon_uuid_opt(reader));
+                        uuid = xml::read_custom_icon_uuid_opt(reader)?;
                     }
                     _ => {}
                 }
@@ -400,24 +400,24 @@ fn read_custom_icon<R: Read>(reader: &mut EventReader<R>) -> Result<(CustomIconU
 
 fn read_memory_protection<R: Read>(reader: &mut EventReader<R>, data: &mut XmlData) -> Result<()> {
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::PROTECT_NOTES_TAG => {
-                        data.protect_notes = try!(xml::read_bool(reader));
+                        data.protect_notes = xml::read_bool(reader)?;
                     }
                     kdb2::PROTECT_PASSWORD_TAG => {
-                        data.protect_password = try!(xml::read_bool(reader));
+                        data.protect_password = xml::read_bool(reader)?;
                     }
                     kdb2::PROTECT_TITLE_TAG => {
-                        data.protect_title = try!(xml::read_bool(reader));
+                        data.protect_title = xml::read_bool(reader)?;
                     }
                     kdb2::PROTECT_URL_TAG => {
-                        data.protect_url = try!(xml::read_bool(reader));
+                        data.protect_url = xml::read_bool(reader)?;
                     }
                     kdb2::PROTECT_USERNAME_TAG => {
-                        data.protect_username = try!(xml::read_bool(reader));
+                        data.protect_username = xml::read_bool(reader)?;
                     }
                     _ => {}
                 }
@@ -439,50 +439,48 @@ fn read_memory_protection<R: Read>(reader: &mut EventReader<R>, data: &mut XmlDa
 fn read_group<R: Read>(reader: &mut EventReader<R>, cipher: &mut Salsa20) -> Result<Group> {
     let mut node = Group::default();
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::CUSTOM_ICON_UUID_TAG => {
-                        node.custom_icon_uuid = try!(xml::read_custom_icon_uuid_opt(reader));
+                        node.custom_icon_uuid = xml::read_custom_icon_uuid_opt(reader)?;
                     }
                     kdb2::DEFAULT_AUTO_TYPE_SEQUENCE_TAG => {
-                        node.def_auto_type_sequence = try!(xml::read_string(reader));
+                        node.def_auto_type_sequence = xml::read_string(reader)?;
                     }
                     kdb2::ENABLE_AUTO_TYPE_TAG => {
-                        node.enable_auto_type = try!(xml::read_bool_opt(reader));
+                        node.enable_auto_type = xml::read_bool_opt(reader)?;
                     }
                     kdb2::ENABLE_SEARCHING_TAG => {
-                        node.enable_searching = try!(xml::read_bool_opt(reader));
+                        node.enable_searching = xml::read_bool_opt(reader)?;
                     }
                     kdb2::ENTRY_TAG => {
-                        node.entries.push(try!(
-                            read_entry(reader, cipher, EntryState::Active)
-                        ));
+                        node.entries.push(read_entry(reader, cipher, EntryState::Active)?);
                     }
                     kdb2::GROUP_TAG => {
-                        node.groups.push(try!(read_group(reader, cipher)));
+                        node.groups.push(read_group(reader, cipher)?);
                     }
                     kdb2::ICON_ID_TAG => {
-                        node.icon = try!(xml::read_icon(reader));
+                        node.icon = xml::read_icon(reader)?;
                     }
                     kdb2::IS_EXPANDED_TAG => {
-                        node.is_expanded = try!(xml::read_bool(reader));
+                        node.is_expanded = xml::read_bool(reader)?;
                     }
                     kdb2::LAST_TOP_VISIBLE_ENTRY_TAG => {
-                        node.last_top_visible_entry = EntryUuid(try!(xml::read_uuid(reader)));
+                        node.last_top_visible_entry = EntryUuid(xml::read_uuid(reader)?);
                     }
                     kdb2::NAME_TAG => {
-                        node.name = try!(xml::read_string(reader));
+                        node.name = xml::read_string(reader)?;
                     }
                     kdb2::NOTES_TAG => {
-                        node.notes = try!(xml::read_string(reader));
+                        node.notes = xml::read_string(reader)?;
                     }
                     kdb2::TIMES_TAG => {
-                        try!(read_times(reader, &mut node));
+                        read_times(reader, &mut node)?;
                     }
                     kdb2::UUID_TAG => {
-                        node.uuid = GroupUuid(try!(xml::read_uuid(reader)));
+                        node.uuid = GroupUuid(xml::read_uuid(reader)?);
                     }
                     _ => {}
                 }
@@ -508,49 +506,49 @@ fn read_entry<R: Read>(
 ) -> Result<Entry> {
     let mut node = Entry::default();
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::AUTO_TYPE_TAG => {
-                        try!(read_auto_type(reader, &mut node));
+                        read_auto_type(reader, &mut node)?;
                     }
                     kdb2::BACKGROUND_COLOR_TAG => {
-                        node.background_color = try!(xml::read_color_opt(reader));
+                        node.background_color = xml::read_color_opt(reader)?;
                     }
                     kdb2::BINARY_TAG => {
-                        let (key, value) = try!(read_binary(reader, cipher));
+                        let (key, value) = read_binary(reader, cipher)?;
                         node.binaries.insert(key, value);
                     }
                     kdb2::CUSTOM_ICON_UUID_TAG => {
-                        node.custom_icon_uuid = try!(xml::read_custom_icon_uuid_opt(reader));
+                        node.custom_icon_uuid = xml::read_custom_icon_uuid_opt(reader)?;
                     }
                     kdb2::FOREGROUND_COLOR_TAG => {
-                        node.foreground_color = try!(xml::read_color_opt(reader));
+                        node.foreground_color = xml::read_color_opt(reader)?;
                     }
                     kdb2::HISTORY_TAG => {
                         if state == EntryState::Active {
-                            node.history.append(&mut try!(read_history(reader, cipher)));
+                            node.history.append(&mut read_history(reader, cipher)?);
                         }
                     }
                     kdb2::ICON_ID_TAG => {
-                        node.icon = try!(xml::read_icon(reader));
+                        node.icon = xml::read_icon(reader)?;
                     }
                     kdb2::OVERRIDE_URL_TAG => {
-                        node.override_url = try!(xml::read_string(reader));
+                        node.override_url = xml::read_string(reader)?;
                     }
                     kdb2::STRING_TAG => {
-                        let (key, value) = try!(read_string(reader, cipher));
+                        let (key, value) = read_string(reader, cipher)?;
                         node.strings.insert(key, value);
                     }
                     kdb2::TAGS_TAG => {
-                        node.tags = try!(xml::read_string(reader));
+                        node.tags = xml::read_string(reader)?;
                     }
                     kdb2::TIMES_TAG => {
-                        try!(read_times(reader, &mut node));
+                        read_times(reader, &mut node)?;
                     }
                     kdb2::UUID_TAG => {
-                        node.uuid = EntryUuid(try!(xml::read_uuid(reader)));
+                        node.uuid = EntryUuid(xml::read_uuid(reader)?);
                     }
                     _ => {}
                 }
@@ -570,7 +568,7 @@ fn read_entry<R: Read>(
 
 fn read_auto_type<R: Read>(reader: &mut EventReader<R>, node: &mut Entry) -> Result<()> {
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 #[allow(unused_must_use)]
@@ -582,13 +580,13 @@ fn read_auto_type<R: Read>(reader: &mut EventReader<R>, node: &mut Entry) -> Res
                         ;
                     }
                     kdb2::DATA_TRANSFER_OBFUSCATION_TAG => {
-                        node.auto_type_obfuscation = try!(xml::read_obfuscation(reader));
+                        node.auto_type_obfuscation = xml::read_obfuscation(reader)?;
                     }
                     kdb2::DEFAULT_SEQUENCE_TAG => {
-                        node.auto_type_def_sequence = try!(xml::read_string(reader));
+                        node.auto_type_def_sequence = xml::read_string(reader)?;
                     }
                     kdb2::ENABLED_TAG => {
-                        node.auto_type_enabled = try!(xml::read_bool(reader));
+                        node.auto_type_enabled = xml::read_bool(reader)?;
                     }
                     _ => {}
                 }
@@ -610,15 +608,15 @@ fn read_association<R: Read>(reader: &mut EventReader<R>) -> Result<Association>
     let mut keystroke: Option<String> = None;
     let mut window: Option<String> = None;
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::KEYSTROKE_SEQUENCE_TAG => {
-                        keystroke = try!(xml::read_string_opt(reader));
+                        keystroke = xml::read_string_opt(reader)?;
                     }
                     kdb2::WINDOW_TAG => {
-                        window = try!(xml::read_string_opt(reader));
+                        window = xml::read_string_opt(reader)?;
                     }
                     _ => {}
                 }
@@ -657,15 +655,15 @@ fn read_binary<R: Read>(
     let mut key: Option<BinaryKey> = None;
     let mut value: Option<BinaryValue> = None;
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, attributes, .. } => {
                 match name.local_name.as_str() {
                     kdb2::KEY_TAG => {
-                        key = try!(xml::read_binary_key_opt(reader));
+                        key = xml::read_binary_key_opt(reader)?;
                     }
                     kdb2::VALUE_TAG => {
-                        value = try!(xml::read_binary_value_opt(reader, cipher, &attributes));
+                        value = xml::read_binary_value_opt(reader, cipher, &attributes)?;
                     }
                     _ => {}
                 }
@@ -697,12 +695,12 @@ fn read_binary<R: Read>(
 fn read_history<R: Read>(reader: &mut EventReader<R>, cipher: &mut Salsa20) -> Result<Vec<Entry>> {
     let mut list = Vec::new();
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::ENTRY_TAG => {
-                        list.push(try!(read_entry(reader, cipher, EntryState::History)));
+                        list.push(read_entry(reader, cipher, EntryState::History)?);
                     }
                     _ => {}
                 }
@@ -728,15 +726,15 @@ fn read_string<R: Read>(
     let mut key: Option<StringKey> = None;
     let mut value: Option<StringValue> = None;
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, attributes, .. } => {
                 match name.local_name.as_str() {
                     kdb2::KEY_TAG => {
-                        key = try!(xml::read_string_key_opt(reader));
+                        key = xml::read_string_key_opt(reader)?;
                     }
                     kdb2::VALUE_TAG => {
-                        value = try!(xml::read_string_value_opt(reader, cipher, &attributes));
+                        value = xml::read_string_value_opt(reader, cipher, &attributes)?;
                     }
                     _ => {}
                 }
@@ -771,30 +769,30 @@ where
     R: Read,
 {
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::CREATION_TIME_TAG => {
-                        node.set_creation_time(try!(xml::read_datetime(reader)));
+                        node.set_creation_time(xml::read_datetime(reader)?);
                     }
                     kdb2::EXPIRY_TIME_TAG => {
-                        node.set_expiry_time(try!(xml::read_datetime(reader)));
+                        node.set_expiry_time(xml::read_datetime(reader)?);
                     }
                     kdb2::EXPIRES_TAG => {
-                        node.set_expires(try!(xml::read_bool(reader)));
+                        node.set_expires(xml::read_bool(reader)?);
                     }
                     kdb2::LAST_ACCESS_TIME_TAG => {
-                        node.set_last_accessed(try!(xml::read_datetime(reader)));
+                        node.set_last_accessed(xml::read_datetime(reader)?);
                     }
                     kdb2::LAST_MODIFICATION_TIME_TAG => {
-                        node.set_last_modified(try!(xml::read_datetime(reader)));
+                        node.set_last_modified(xml::read_datetime(reader)?);
                     }
                     kdb2::LOCATION_CHANGED_TAG => {
-                        node.set_location_changed(try!(xml::read_datetime(reader)));
+                        node.set_location_changed(xml::read_datetime(reader)?);
                     }
                     kdb2::USAGE_COUNT_TAG => {
-                        node.set_usage_count(try!(xml::read_i32(reader)));
+                        node.set_usage_count(xml::read_i32(reader)?);
                     }
                     _ => {}
                 }

--- a/src/format/kdb2_xml_reader.rs
+++ b/src/format/kdb2_xml_reader.rs
@@ -575,7 +575,10 @@ fn read_auto_type<R: Read>(reader: &mut EventReader<R>, node: &mut Entry) -> Res
             XmlEvent::StartElement { name, .. } => {
                 match name.local_name.as_str() {
                     kdb2::ASSOCIATION_TAG => {
-                        node.associations.push(try!(read_association(reader)));
+                        read_association(reader)
+                            .map(|x| node.associations.push(x))
+                            .map_err(|err| eprintln!("{}", err))
+                        ;
                     }
                     kdb2::DATA_TRANSFER_OBFUSCATION_TAG => {
                         node.auto_type_obfuscation = try!(xml::read_obfuscation(reader));

--- a/src/format/kdb2_xml_reader.rs
+++ b/src/format/kdb2_xml_reader.rs
@@ -573,6 +573,7 @@ fn read_auto_type<R: Read>(reader: &mut EventReader<R>, node: &mut Entry) -> Res
         let event = try!(reader.next());
         match event {
             XmlEvent::StartElement { name, .. } => {
+                #[allow(unused_must_use)]
                 match name.local_name.as_str() {
                     kdb2::ASSOCIATION_TAG => {
                         read_association(reader)

--- a/src/format/kdb2_xml_writer.rs
+++ b/src/format/kdb2_xml_writer.rs
@@ -45,7 +45,7 @@ pub fn write<W: Write>(
 
     {
         let mut writer = EventWriter::new_with_config(writer, config);
-        try!(write_kee_pass_file_section(&mut writer, db, hash, &mut cipher));
+        write_kee_pass_file_section(&mut writer, db, hash, &mut cipher)?;
     }
 
     Ok(())
@@ -55,24 +55,24 @@ fn write_association_section<W: Write>(
     writer: &mut EventWriter<W>,
     assoc: &Association,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::ASSOCIATION_TAG));
-    try!(xml::write_string_tag(writer, kdb2::KEYSTROKE_SEQUENCE_TAG, &assoc.keystroke_sequence));
-    try!(xml::write_string_tag(writer, kdb2::WINDOW_TAG, &assoc.window));
+    xml::write_start_tag(writer, kdb2::ASSOCIATION_TAG)?;
+    xml::write_string_tag(writer, kdb2::KEYSTROKE_SEQUENCE_TAG, &assoc.keystroke_sequence)?;
+    xml::write_string_tag(writer, kdb2::WINDOW_TAG, &assoc.window)?;
     xml::write_end_tag(writer)
 }
 
 fn write_auto_type_section<W: Write>(writer: &mut EventWriter<W>, entry: &Entry) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::AUTO_TYPE_TAG));
-    try!(xml::write_i32_tag(
+    xml::write_start_tag(writer, kdb2::AUTO_TYPE_TAG)?;
+    xml::write_i32_tag(
         writer,
         kdb2::DATA_TRANSFER_OBFUSCATION_TAG,
         entry.auto_type_obfuscation.to_i32(),
-    ));
-    try!(xml::write_string_tag(writer, kdb2::DEFAULT_SEQUENCE_TAG, &entry.auto_type_def_sequence));
-    try!(xml::write_bool_tag(writer, kdb2::ENABLED_TAG, entry.auto_type_enabled));
+    )?;
+    xml::write_string_tag(writer, kdb2::DEFAULT_SEQUENCE_TAG, &entry.auto_type_def_sequence)?;
+    xml::write_bool_tag(writer, kdb2::ENABLED_TAG, entry.auto_type_enabled)?;
 
     for assoc in &entry.associations {
-        try!(write_association_section(writer, assoc));
+        write_association_section(writer, assoc)?;
     }
     xml::write_end_tag(writer)
 }
@@ -83,31 +83,31 @@ fn write_binary_section<W: Write>(
     key: &BinaryKey,
     value: &BinaryValue,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::BINARY_TAG));
-    try!(xml::write_start_tag(writer, kdb2::KEY_TAG));
-    try!(xml::write_string(writer, &key.0));
-    try!(xml::write_end_tag(writer));
+    xml::write_start_tag(writer, kdb2::BINARY_TAG)?;
+    xml::write_start_tag(writer, kdb2::KEY_TAG)?;
+    xml::write_string(writer, &key.0)?;
+    xml::write_end_tag(writer)?;
 
     match *value {
         BinaryValue::Plain(ref bytes) => {
-            try!(xml::write_start_tag(writer, kdb2::VALUE_TAG));
-            try!(xml::write_binary(writer, bytes));
-            try!(xml::write_end_tag(writer));
+            xml::write_start_tag(writer, kdb2::VALUE_TAG)?;
+            xml::write_binary(writer, bytes)?;
+            xml::write_end_tag(writer)?;
         }
         BinaryValue::Protected(ref sec) => {
             let tag = XmlEvent::start_element(kdb2::VALUE_TAG);
             let tag = tag.attr("Protected", "True");
-            try!(writer.write(tag));
+            writer.write(tag)?;
             let plain = sec.unsecure().to_vec();
             let encrypted = salsa20::encrypt(cipher, &plain);
-            try!(xml::write_binary(writer, encrypted.as_slice()));
-            try!(xml::write_end_tag(writer));
+            xml::write_binary(writer, encrypted.as_slice())?;
+            xml::write_end_tag(writer)?;
         }
         BinaryValue::Ref(ref binary_id) => {
             let tag = XmlEvent::start_element(kdb2::VALUE_TAG);
             let tag = tag.attr("Ref", binary_id.0.as_str());
-            try!(writer.write(tag));
-            try!(xml::write_end_tag(writer));
+            writer.write(tag)?;
+            xml::write_end_tag(writer)?;
         }
     }
     xml::write_end_tag(writer)
@@ -118,14 +118,14 @@ fn write_binaries_section<W: Write>(
     writer: &mut EventWriter<W>,
     binaries: &BinariesMap,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::BINARIES_TAG));
+    xml::write_start_tag(writer, kdb2::BINARIES_TAG)?;
     for (id, data) in binaries {
         let tag = XmlEvent::start_element(kdb2::BINARY_TAG);
         let tag = tag.attr("ID", id.0.as_str());
         let tag = tag.attr("Compressed", "True");
-        try!(writer.write(tag));
-        try!(xml::write_gzip(writer, &data));
-        try!(xml::write_end_tag(writer));
+        writer.write(tag)?;
+        xml::write_gzip(writer, &data)?;
+        xml::write_end_tag(writer)?;
     }
     xml::write_end_tag(writer)
 }
@@ -134,9 +134,9 @@ fn write_custom_data_section<W: Write>(
     writer: &mut EventWriter<W>,
     data: &CustomDataMap,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::CUSTOM_DATA_TAG));
+    xml::write_start_tag(writer, kdb2::CUSTOM_DATA_TAG)?;
     for (key, value) in data {
-        try!(write_custom_data_item_section(writer, key, value));
+        write_custom_data_item_section(writer, key, value)?;
     }
     xml::write_end_tag(writer)
 }
@@ -146,9 +146,9 @@ fn write_custom_data_item_section<W: Write>(
     key: &String,
     value: &String,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::ITEM_TAG));
-    try!(xml::write_string_tag(writer, kdb2::KEY_TAG, key));
-    try!(xml::write_string_tag(writer, kdb2::VALUE_TAG, value));
+    xml::write_start_tag(writer, kdb2::ITEM_TAG)?;
+    xml::write_string_tag(writer, kdb2::KEY_TAG, key)?;
+    xml::write_string_tag(writer, kdb2::VALUE_TAG, value)?;
     xml::write_end_tag(writer)
 }
 
@@ -156,9 +156,9 @@ fn write_custom_icons_section<W: Write>(
     writer: &mut EventWriter<W>,
     icons: &CustomIconsMap,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::CUSTOM_ICONS_TAG));
+    xml::write_start_tag(writer, kdb2::CUSTOM_ICONS_TAG)?;
     for (uuid, icon) in icons {
-        try!(write_custom_icon_section(writer, uuid, icon));
+        write_custom_icon_section(writer, uuid, icon)?;
     }
     xml::write_end_tag(writer)
 }
@@ -168,9 +168,9 @@ fn write_custom_icon_section<W: Write>(
     uuid: &CustomIconUuid,
     icon: &Vec<u8>,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::ICON_TAG));
-    try!(xml::write_uuid_tag(writer, kdb2::UUID_TAG, &uuid.0));
-    try!(xml::write_binary_tag(writer, kdb2::DATA_TAG, icon));
+    xml::write_start_tag(writer, kdb2::ICON_TAG)?;
+    xml::write_uuid_tag(writer, kdb2::UUID_TAG, &uuid.0)?;
+    xml::write_binary_tag(writer, kdb2::DATA_TAG, icon)?;
     xml::write_end_tag(writer)
 }
 
@@ -180,31 +180,31 @@ fn write_entry_section<W: Write>(
     entry: &Entry,
     state: EntryState,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::ENTRY_TAG));
-    try!(xml::write_uuid_tag(writer, kdb2::UUID_TAG, &entry.uuid.0));
-    try!(write_auto_type_section(writer, entry));
-    try!(xml::write_color_tag(writer, kdb2::BACKGROUND_COLOR_TAG, &entry.background_color));
-    try!(xml::write_custom_icon_uuid_tag(
+    xml::write_start_tag(writer, kdb2::ENTRY_TAG)?;
+    xml::write_uuid_tag(writer, kdb2::UUID_TAG, &entry.uuid.0)?;
+    write_auto_type_section(writer, entry)?;
+    xml::write_color_tag(writer, kdb2::BACKGROUND_COLOR_TAG, &entry.background_color)?;
+    xml::write_custom_icon_uuid_tag(
         writer,
         kdb2::CUSTOM_ICON_UUID_TAG,
         &entry.custom_icon_uuid,
-    ));
-    try!(xml::write_color_tag(writer, kdb2::FOREGROUND_COLOR_TAG, &entry.foreground_color));
-    try!(xml::write_i32_tag(writer, kdb2::ICON_ID_TAG, entry.icon.to_i32()));
-    try!(xml::write_string_tag(writer, kdb2::OVERRIDE_URL_TAG, &entry.override_url));
-    try!(xml::write_string_tag(writer, kdb2::TAGS_TAG, &entry.tags));
-    try!(write_times_section(writer, entry));
+    )?;
+    xml::write_color_tag(writer, kdb2::FOREGROUND_COLOR_TAG, &entry.foreground_color)?;
+    xml::write_i32_tag(writer, kdb2::ICON_ID_TAG, entry.icon.to_i32())?;
+    xml::write_string_tag(writer, kdb2::OVERRIDE_URL_TAG, &entry.override_url)?;
+    xml::write_string_tag(writer, kdb2::TAGS_TAG, &entry.tags)?;
+    write_times_section(writer, entry)?;
 
     for (key, value) in &entry.binaries {
-        try!(write_binary_section(writer, cipher, key, value));
+        write_binary_section(writer, cipher, key, value)?;
     }
 
     for (key, value) in &entry.strings {
-        try!(write_string_section(writer, cipher, key, value));
+        write_string_section(writer, cipher, key, value)?;
     }
 
     if state == EntryState::Active {
-        try!(write_history_section(writer, cipher, &entry.history));
+        write_history_section(writer, cipher, &entry.history)?;
     }
     xml::write_end_tag(writer)
 }
@@ -214,32 +214,32 @@ fn write_group_section<W: Write>(
     cipher: &mut Salsa20,
     group: &Group,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::GROUP_TAG));
-    try!(xml::write_uuid_tag(writer, kdb2::UUID_TAG, &group.uuid.0));
-    try!(xml::write_string_tag(
+    xml::write_start_tag(writer, kdb2::GROUP_TAG)?;
+    xml::write_uuid_tag(writer, kdb2::UUID_TAG, &group.uuid.0)?;
+    xml::write_string_tag(
         writer,
         kdb2::DEFAULT_AUTO_TYPE_SEQUENCE_TAG,
         &group.def_auto_type_sequence,
-    ));
-    try!(xml::write_bool_opt_tag(writer, kdb2::ENABLE_AUTO_TYPE_TAG, &group.enable_auto_type));
-    try!(xml::write_bool_opt_tag(writer, kdb2::ENABLE_SEARCHING_TAG, &group.enable_searching));
-    try!(xml::write_i32_tag(writer, kdb2::ICON_ID_TAG, group.icon.to_i32()));
-    try!(xml::write_bool_tag(writer, kdb2::IS_EXPANDED_TAG, group.is_expanded));
-    try!(xml::write_uuid_tag(
+    )?;
+    xml::write_bool_opt_tag(writer, kdb2::ENABLE_AUTO_TYPE_TAG, &group.enable_auto_type)?;
+    xml::write_bool_opt_tag(writer, kdb2::ENABLE_SEARCHING_TAG, &group.enable_searching)?;
+    xml::write_i32_tag(writer, kdb2::ICON_ID_TAG, group.icon.to_i32())?;
+    xml::write_bool_tag(writer, kdb2::IS_EXPANDED_TAG, group.is_expanded)?;
+    xml::write_uuid_tag(
         writer,
         kdb2::LAST_TOP_VISIBLE_ENTRY_TAG,
         &group.last_top_visible_entry.0,
-    ));
-    try!(xml::write_string_tag(writer, kdb2::NAME_TAG, &group.name));
-    try!(xml::write_string_tag(writer, kdb2::NOTES_TAG, &group.notes));
-    try!(write_times_section(writer, group));
+    )?;
+    xml::write_string_tag(writer, kdb2::NAME_TAG, &group.name)?;
+    xml::write_string_tag(writer, kdb2::NOTES_TAG, &group.notes)?;
+    write_times_section(writer, group)?;
 
     for entry in &group.entries {
-        try!(write_entry_section(writer, cipher, entry, EntryState::Active));
+        write_entry_section(writer, cipher, entry, EntryState::Active)?;
     }
 
     for subgroup in &group.groups {
-        try!(write_group_section(writer, cipher, subgroup));
+        write_group_section(writer, cipher, subgroup)?;
     }
 
     xml::write_end_tag(writer)
@@ -250,9 +250,9 @@ fn write_history_section<W: Write>(
     cipher: &mut Salsa20,
     entries: &Vec<Entry>,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::HISTORY_TAG));
+    xml::write_start_tag(writer, kdb2::HISTORY_TAG)?;
     for entry in entries {
-        try!(write_entry_section(writer, cipher, entry, EntryState::History));
+        write_entry_section(writer, cipher, entry, EntryState::History)?;
     }
     xml::write_end_tag(writer)
 }
@@ -263,9 +263,9 @@ fn write_kee_pass_file_section<W: Write>(
     hash: &HeaderHash,
     cipher: &mut Salsa20,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::KEE_PASS_FILE_TAG));
-    try!(write_meta_section(writer, db, hash));
-    try!(write_root_section(writer, db, cipher));
+    xml::write_start_tag(writer, kdb2::KEE_PASS_FILE_TAG)?;
+    write_meta_section(writer, db, hash)?;
+    write_root_section(writer, db, cipher)?;
     xml::write_end_tag(writer)
 }
 
@@ -273,12 +273,12 @@ fn write_memory_protection_section<W: Write>(
     writer: &mut EventWriter<W>,
     db: &Database,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::MEMORY_PROTECTION_TAG));
-    try!(xml::write_bool_tag(writer, kdb2::PROTECT_NOTES_TAG, db.protect_notes));
-    try!(xml::write_bool_tag(writer, kdb2::PROTECT_PASSWORD_TAG, db.protect_password));
-    try!(xml::write_bool_tag(writer, kdb2::PROTECT_TITLE_TAG, db.protect_title));
-    try!(xml::write_bool_tag(writer, kdb2::PROTECT_URL_TAG, db.protect_url));
-    try!(xml::write_bool_tag(writer, kdb2::PROTECT_USERNAME_TAG, db.protect_username));
+    xml::write_start_tag(writer, kdb2::MEMORY_PROTECTION_TAG)?;
+    xml::write_bool_tag(writer, kdb2::PROTECT_NOTES_TAG, db.protect_notes)?;
+    xml::write_bool_tag(writer, kdb2::PROTECT_PASSWORD_TAG, db.protect_password)?;
+    xml::write_bool_tag(writer, kdb2::PROTECT_TITLE_TAG, db.protect_title)?;
+    xml::write_bool_tag(writer, kdb2::PROTECT_URL_TAG, db.protect_url)?;
+    xml::write_bool_tag(writer, kdb2::PROTECT_USERNAME_TAG, db.protect_username)?;
     xml::write_end_tag(writer)
 }
 
@@ -287,58 +287,58 @@ fn write_meta_section<W: Write>(
     db: &Database,
     hash: &HeaderHash,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::META_TAG));
-    try!(write_binaries_section(writer, &db.binaries));
-    try!(xml::write_color_tag(writer, kdb2::COLOR_TAG, &db.color));
-    try!(write_custom_data_section(writer, &db.custom_data));
-    try!(write_custom_icons_section(writer, &db.custom_icons));
-    try!(xml::write_string_tag(writer, kdb2::DATABASE_DESCRIPTION_TAG, &db.description));
-    try!(xml::write_datetime_tag(
+    xml::write_start_tag(writer, kdb2::META_TAG)?;
+    write_binaries_section(writer, &db.binaries)?;
+    xml::write_color_tag(writer, kdb2::COLOR_TAG, &db.color)?;
+    write_custom_data_section(writer, &db.custom_data)?;
+    write_custom_icons_section(writer, &db.custom_icons)?;
+    xml::write_string_tag(writer, kdb2::DATABASE_DESCRIPTION_TAG, &db.description)?;
+    xml::write_datetime_tag(
         writer,
         kdb2::DATABASE_DESCRIPTION_CHANGED_TAG,
         &db.description_changed,
-    ));
-    try!(xml::write_string_tag(writer, kdb2::DATABASE_NAME_TAG, &db.name));
-    try!(xml::write_datetime_tag(writer, kdb2::DATABASE_NAME_CHANGED_TAG, &db.name_changed));
-    try!(xml::write_string_tag(writer, kdb2::DEFAULT_USERNAME_TAG, &db.def_username));
-    try!(xml::write_datetime_tag(
+    )?;
+    xml::write_string_tag(writer, kdb2::DATABASE_NAME_TAG, &db.name)?;
+    xml::write_datetime_tag(writer, kdb2::DATABASE_NAME_CHANGED_TAG, &db.name_changed)?;
+    xml::write_string_tag(writer, kdb2::DEFAULT_USERNAME_TAG, &db.def_username)?;
+    xml::write_datetime_tag(
         writer,
         kdb2::DEFAULT_USERNAME_CHANGED_TAG,
         &db.def_username_changed,
-    ));
-    try!(xml::write_uuid_tag(
+    )?;
+    xml::write_uuid_tag(
         writer,
         kdb2::ENTRY_TEMPLATES_GROUP_TAG,
         &db.entry_templates_group_uuid.0,
-    ));
-    try!(xml::write_datetime_tag(
+    )?;
+    xml::write_datetime_tag(
         writer,
         kdb2::ENTRY_TEMPLATES_GROUP_CHANGED_TAG,
         &db.entry_templates_group_changed,
-    ));
-    try!(xml::write_string_tag(writer, kdb2::GENERATOR_TAG, &String::from(common::GENERATOR_NAME)));
-    try!(xml::write_binary_tag(writer, kdb2::HEADER_HASH_TAG, &hash.0));
-    try!(xml::write_i32_tag(writer, kdb2::HISTORY_MAX_ITEMS_TAG, db.history_max_items));
-    try!(xml::write_i32_tag(writer, kdb2::HISTORY_MAX_SIZE_TAG, db.history_max_size));
-    try!(xml::write_uuid_tag(writer, kdb2::LAST_SELECTED_GROUP_TAG, &db.last_selected_group.0));
-    try!(xml::write_uuid_tag(
+    )?;
+    xml::write_string_tag(writer, kdb2::GENERATOR_TAG, &String::from(common::GENERATOR_NAME))?;
+    xml::write_binary_tag(writer, kdb2::HEADER_HASH_TAG, &hash.0)?;
+    xml::write_i32_tag(writer, kdb2::HISTORY_MAX_ITEMS_TAG, db.history_max_items)?;
+    xml::write_i32_tag(writer, kdb2::HISTORY_MAX_SIZE_TAG, db.history_max_size)?;
+    xml::write_uuid_tag(writer, kdb2::LAST_SELECTED_GROUP_TAG, &db.last_selected_group.0)?;
+    xml::write_uuid_tag(
         writer,
         kdb2::LAST_TOP_VISIBLE_GROUP_TAG,
         &db.last_top_visible_group.0,
-    ));
-    try!(xml::write_i32_tag(
+    )?;
+    xml::write_i32_tag(
         writer,
         kdb2::MAINTENANCE_HISTORY_DAYS_TAG,
         db.maintenance_history_days,
-    ));
-    try!(xml::write_i32_tag(writer, kdb2::MASTER_KEY_CHANGE_FORCE_TAG, db.master_key_change_force));
-    try!(xml::write_i32_tag(writer, kdb2::MASTER_KEY_CHANGE_REC_TAG, db.master_key_change_rec));
-    try!(xml::write_datetime_tag(writer, kdb2::MASTER_KEY_CHANGED_TAG, &db.master_key_changed));
+    )?;
+    xml::write_i32_tag(writer, kdb2::MASTER_KEY_CHANGE_FORCE_TAG, db.master_key_change_force)?;
+    xml::write_i32_tag(writer, kdb2::MASTER_KEY_CHANGE_REC_TAG, db.master_key_change_rec)?;
+    xml::write_datetime_tag(writer, kdb2::MASTER_KEY_CHANGED_TAG, &db.master_key_changed)?;
 
-    try!(write_memory_protection_section(writer, &db));
-    try!(xml::write_datetime_tag(writer, kdb2::RECYCLE_BIN_CHANGED_TAG, &db.recycle_bin_changed));
-    try!(xml::write_bool_tag(writer, kdb2::RECYCLE_BIN_ENABLED_TAG, db.recycle_bin_enabled));
-    try!(xml::write_uuid_tag(writer, kdb2::RECYCLE_BIN_UUID_TAG, &db.recycle_bin_uuid.0));
+    write_memory_protection_section(writer, &db)?;
+    xml::write_datetime_tag(writer, kdb2::RECYCLE_BIN_CHANGED_TAG, &db.recycle_bin_changed)?;
+    xml::write_bool_tag(writer, kdb2::RECYCLE_BIN_ENABLED_TAG, db.recycle_bin_enabled)?;
+    xml::write_uuid_tag(writer, kdb2::RECYCLE_BIN_UUID_TAG, &db.recycle_bin_uuid.0)?;
     xml::write_end_tag(writer)
 }
 
@@ -347,8 +347,8 @@ fn write_root_section<W: Write>(
     db: &Database,
     cipher: &mut Salsa20,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::ROOT_TAG));
-    try!(write_group_section(writer, cipher, &db.root_group));
+    xml::write_start_tag(writer, kdb2::ROOT_TAG)?;
+    write_group_section(writer, cipher, &db.root_group)?;
     xml::write_end_tag(writer)
 }
 
@@ -358,21 +358,21 @@ fn write_string_section<W: Write>(
     key: &StringKey,
     value: &StringValue,
 ) -> Result<()> {
-    try!(xml::write_start_tag(writer, kdb2::STRING_TAG));
-    try!(xml::write_string_tag(writer, kdb2::KEY_TAG, &key.to_string()));
+    xml::write_start_tag(writer, kdb2::STRING_TAG)?;
+    xml::write_string_tag(writer, kdb2::KEY_TAG, &key.to_string())?;
 
     match *value {
         StringValue::Plain(ref string) => {
-            try!(xml::write_string_tag(writer, kdb2::VALUE_TAG, string));
+            xml::write_string_tag(writer, kdb2::VALUE_TAG, string)?;
         }
         StringValue::Protected(ref sec) => {
             let tag = XmlEvent::start_element(kdb2::VALUE_TAG);
             let tag = tag.attr("Protected", "True");
-            try!(writer.write(tag));
+            writer.write(tag)?;
             let plain = sec.unsecure().to_vec();
             let encrypted = salsa20::encrypt(cipher, &plain);
-            try!(xml::write_binary(writer, encrypted.as_slice()));
-            try!(xml::write_end_tag(writer));
+            xml::write_binary(writer, encrypted.as_slice())?;
+            xml::write_end_tag(writer)?;
         }
     }
     xml::write_end_tag(writer)
@@ -383,13 +383,13 @@ where
     T: Times,
     W: Write,
 {
-    try!(xml::write_start_tag(writer, kdb2::TIMES_TAG));
-    try!(xml::write_datetime_tag(writer, kdb2::CREATION_TIME_TAG, &node.creation_time()));
-    try!(xml::write_datetime_tag(writer, kdb2::EXPIRY_TIME_TAG, &node.expiry_time()));
-    try!(xml::write_bool_tag(writer, kdb2::EXPIRES_TAG, node.expires()));
-    try!(xml::write_datetime_tag(writer, kdb2::LAST_ACCESS_TIME_TAG, &node.last_accessed()));
-    try!(xml::write_datetime_tag(writer, kdb2::LAST_MODIFICATION_TIME_TAG, &node.last_modified()));
-    try!(xml::write_datetime_tag(writer, kdb2::LOCATION_CHANGED_TAG, &node.location_changed()));
-    try!(xml::write_i32_tag(writer, kdb2::USAGE_COUNT_TAG, node.usage_count()));
+    xml::write_start_tag(writer, kdb2::TIMES_TAG)?;
+    xml::write_datetime_tag(writer, kdb2::CREATION_TIME_TAG, &node.creation_time())?;
+    xml::write_datetime_tag(writer, kdb2::EXPIRY_TIME_TAG, &node.expiry_time())?;
+    xml::write_bool_tag(writer, kdb2::EXPIRES_TAG, node.expires())?;
+    xml::write_datetime_tag(writer, kdb2::LAST_ACCESS_TIME_TAG, &node.last_accessed())?;
+    xml::write_datetime_tag(writer, kdb2::LAST_MODIFICATION_TIME_TAG, &node.last_modified())?;
+    xml::write_datetime_tag(writer, kdb2::LOCATION_CHANGED_TAG, &node.location_changed())?;
+    xml::write_i32_tag(writer, kdb2::USAGE_COUNT_TAG, node.usage_count())?;
     xml::write_end_tag(writer)
 }

--- a/src/format/kf_reader.rs
+++ b/src/format/kf_reader.rs
@@ -18,7 +18,7 @@ use xml::reader::{EventReader, XmlEvent};
 /// Attempts to read a key file from the reader.
 pub fn read<R: Read>(reader: &mut R) -> Result<KeyFile> {
     let mut data = Vec::new();
-    try!(reader.read_to_end(&mut data));
+    reader.read_to_end(&mut data)?;
     match data.len() {
         kf::BINARY_KEY_FILE_LEN => read_binary(data),
         kf::HEX_KEY_FILE_LEN => read_hex(data),
@@ -49,11 +49,11 @@ fn read_xml<R: Read>(reader: &mut R) -> Result<KeyFile> {
     let mut opt_key: Option<SecStr> = None;
     let mut reader = EventReader::new(reader);
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 if name.local_name == kf::KEY_FILE_TAG {
-                    opt_key = Some(try!(read_xml_key_file(&mut reader)));
+                    opt_key = Some(read_xml_key_file(&mut reader)?);
                 }
             }
             XmlEvent::EndDocument { .. } => {
@@ -77,13 +77,13 @@ fn read_xml<R: Read>(reader: &mut R) -> Result<KeyFile> {
 fn read_xml_key_file<R: Read>(reader: &mut EventReader<R>) -> Result<SecStr> {
     let mut opt_key: Option<SecStr> = None;
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 if name.local_name == kf::KEY_TAG {
-                    opt_key = Some(try!(read_xml_key(reader)));
+                    opt_key = Some(read_xml_key(reader)?);
                 } else if name.local_name == kf::META_TAG {
-                    try!(read_xml_meta(reader));
+                    read_xml_meta(reader)?;
                 }
             }
             XmlEvent::EndElement { name, .. } => {
@@ -103,11 +103,11 @@ fn read_xml_key_file<R: Read>(reader: &mut EventReader<R>) -> Result<SecStr> {
 
 fn read_xml_meta<R: Read>(reader: &mut EventReader<R>) -> Result<()> {
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 if name.local_name == kf::VERSION_TAG {
-                    let version = try!(xml::read_string(reader));
+                    let version = xml::read_string(reader)?;
                     if version != kf::XML_KEY_FILE_VERSION {
                         return xml::read_err(reader, "Unsupported key file version");
                     }
@@ -128,11 +128,11 @@ fn read_xml_meta<R: Read>(reader: &mut EventReader<R>) -> Result<()> {
 fn read_xml_key<R: Read>(reader: &mut EventReader<R>) -> Result<SecStr> {
     let mut opt_key: Option<SecStr> = None;
     loop {
-        let event = try!(reader.next());
+        let event = reader.next()?;
         match event {
             XmlEvent::StartElement { name, .. } => {
                 if name.local_name == kf::DATA_TAG {
-                    opt_key = Some(SecStr::new(try!(xml::read_binary(reader))));
+                    opt_key = Some(SecStr::new(xml::read_binary(reader)?));
                 }
             }
             XmlEvent::EndElement { name, .. } => {

--- a/src/format/kf_writer.rs
+++ b/src/format/kf_writer.rs
@@ -24,13 +24,13 @@ pub fn write<W: Write>(writer: &mut W, key: &KeyFile) -> Result<()> {
 }
 
 fn write_binary<W: Write>(writer: &mut W, key: &KeyFile) -> Result<()> {
-    try!(writer.write(key.key.unsecure()));
+    writer.write(key.key.unsecure())?;
     Ok(())
 }
 
 fn write_hex<W: Write>(writer: &mut W, key: &KeyFile) -> Result<()> {
     let hex = key.key.unsecure().to_hex();
-    try!(writer.write(&hex.into_bytes()));
+    writer.write(&hex.into_bytes())?;
     Ok(())
 }
 
@@ -41,26 +41,26 @@ fn write_xml<W: Write>(writer: &mut W, key: &KeyFile) -> Result<()> {
 
     {
         let mut writer = EventWriter::new_with_config(writer, config);
-        try!(write_xml_key_file_section(&mut writer, key));
+        write_xml_key_file_section(&mut writer, key)?;
     }
     Ok(())
 }
 
 fn write_xml_key_file_section<W: Write>(writer: &mut EventWriter<W>, key: &KeyFile) -> Result<()> {
-    try!(xml::write_start_tag(writer, kf::KEY_FILE_TAG));
-    try!(write_xml_meta_section(writer));
-    try!(write_xml_key_section(writer, key));
+    xml::write_start_tag(writer, kf::KEY_FILE_TAG)?;
+    write_xml_meta_section(writer)?;
+    write_xml_key_section(writer, key)?;
     xml::write_end_tag(writer)
 }
 
 fn write_xml_meta_section<W: Write>(writer: &mut EventWriter<W>) -> Result<()> {
-    try!(xml::write_start_tag(writer, kf::META_TAG));
-    try!(xml::write_string_tag(writer, kf::VERSION_TAG, &String::from(kf::XML_KEY_FILE_VERSION)));
+    xml::write_start_tag(writer, kf::META_TAG)?;
+    xml::write_string_tag(writer, kf::VERSION_TAG, &String::from(kf::XML_KEY_FILE_VERSION))?;
     xml::write_end_tag(writer)
 }
 
 fn write_xml_key_section<W: Write>(writer: &mut EventWriter<W>, key: &KeyFile) -> Result<()> {
-    try!(xml::write_start_tag(writer, kf::KEY_TAG));
-    try!(xml::write_binary_tag(writer, kf::DATA_TAG, key.key.unsecure()));
+    xml::write_start_tag(writer, kf::KEY_TAG)?;
+    xml::write_binary_tag(writer, kf::DATA_TAG, key.key.unsecure())?;
     xml::write_end_tag(writer)
 }

--- a/src/format/xml.rs
+++ b/src/format/xml.rs
@@ -244,7 +244,15 @@ pub fn read_string_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<St
     match event {
         reader::XmlEvent::Characters(val) => Ok(Some(val)),
         reader::XmlEvent::EndElement { .. } => Ok(None),
-        _ => read_err(reader, "No characters found"),
+        _ => {
+            let _: Result<Option<String>> = read_err(reader, "No characters found")
+                .map_err(|err| {
+                    eprintln!("{}", err);
+                    err
+                });
+            Ok(None)
+        },
+//        _ => read_err(reader, "No characters found"),
     }
 }
 

--- a/src/format/xml.rs
+++ b/src/format/xml.rs
@@ -33,7 +33,7 @@ use xml::writer::{self, EventWriter};
 
 /// Attempts to read binary data.
 pub fn read_binary<R: Read>(reader: &mut EventReader<R>) -> Result<Vec<u8>> {
-    match try!(read_binary_opt(reader)) {
+    match read_binary_opt(reader)? {
         Some(bytes) => Ok(bytes),
         None => Ok(Vec::new()),
     }
@@ -41,7 +41,7 @@ pub fn read_binary<R: Read>(reader: &mut EventReader<R>) -> Result<Vec<u8>> {
 
 /// Attempts to read an optional binary key.
 pub fn read_binary_key_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<BinaryKey>> {
-    match try!(read_string_opt(reader)) {
+    match read_string_opt(reader)? {
         Some(string) => Ok(Some(BinaryKey(string))),
         None => Ok(None),
     }
@@ -49,7 +49,7 @@ pub fn read_binary_key_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Optio
 
 /// Attempts to read optional binary data.
 pub fn read_binary_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<Vec<u8>>> {
-    match try!(read_string_opt(reader)) {
+    match read_string_opt(reader)? {
         Some(string) => {
             match base64::decode(&string) {
                 Ok(bin) => Ok(Some(bin)),
@@ -67,11 +67,11 @@ pub fn read_binary_value_opt<R: Read>(
     attrs: &Vec<OwnedAttribute>,
 ) -> Result<Option<BinaryValue>> {
     let ref_value = search_attr_value(attrs, "ref");
-    let protected = try!(get_protected_attr_value(reader, attrs));
+    let protected = get_protected_attr_value(reader, attrs)?;
     match ref_value {
         Some(string) => Ok(Some(BinaryValue::Ref(BinaryId(string)))),
         None => {
-            match try!(read_binary_opt(reader)) {
+            match read_binary_opt(reader)? {
                 Some(bytes) => {
                     if protected {
                         let pbytes = salsa20::decrypt(cipher, &bytes);
@@ -95,7 +95,7 @@ pub fn read_binary_value_opt<R: Read>(
 
 /// Attempts to read a boolean.
 pub fn read_bool<R: Read>(reader: &mut EventReader<R>) -> Result<bool> {
-    match try!(read_bool_opt(reader)) {
+    match read_bool_opt(reader)? {
         Some(b) => Ok(b),
         None => read_err(reader, "No Bool value found"),
     }
@@ -103,7 +103,7 @@ pub fn read_bool<R: Read>(reader: &mut EventReader<R>) -> Result<bool> {
 
 /// Attempts to read an optional boolean.
 pub fn read_bool_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<bool>> {
-    match try!(read_string_opt(reader)) {
+    match read_string_opt(reader)? {
         Some(string) => {
             match string.to_lowercase().as_str() {
                 "false" => Ok(Some(false)),
@@ -118,7 +118,7 @@ pub fn read_bool_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<bool
 
 /// Attempts to read an optional color.
 pub fn read_color_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<Color>> {
-    match try!(read_string_opt(reader)) {
+    match read_string_opt(reader)? {
         Some(string) => {
             match Color::from_hex_string(&string) {
                 Ok(color) => Ok(Some(color)),
@@ -133,7 +133,7 @@ pub fn read_color_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<Col
 pub fn read_custom_icon_uuid_opt<R: Read>(
     reader: &mut EventReader<R>,
 ) -> Result<Option<CustomIconUuid>> {
-    match try!(read_uuid_opt(reader)) {
+    match read_uuid_opt(reader)? {
         Some(uuid) => Ok(Some(CustomIconUuid(uuid))),
         None => Ok(None),
     }
@@ -141,7 +141,7 @@ pub fn read_custom_icon_uuid_opt<R: Read>(
 
 /// Attempts to read a date and time.
 pub fn read_datetime<R: Read>(reader: &mut EventReader<R>) -> Result<DateTime<Utc>> {
-    match try!(read_string_opt(reader)) {
+    match read_string_opt(reader)? {
         Some(string) => {
             match string.parse::<DateTime<Utc>>() {
                 Ok(datetime) => Ok(datetime),
@@ -166,9 +166,9 @@ where
 
 /// Attempts to read GZip compressed binary data.
 pub fn read_gzip<R: Read>(reader: &mut EventReader<R>) -> Result<Vec<u8>> {
-    match try!(read_binary_opt(reader)) {
+    match read_binary_opt(reader)? {
         Some(bytes) => {
-            let decompressed = try!(gzip::decode(&bytes));
+            let decompressed = gzip::decode(&bytes)?;
             Ok(decompressed)
         }
         None => Ok(Vec::new()),
@@ -177,7 +177,7 @@ pub fn read_gzip<R: Read>(reader: &mut EventReader<R>) -> Result<Vec<u8>> {
 
 /// Attempts to read an i32.
 pub fn read_i32<R: Read>(reader: &mut EventReader<R>) -> Result<i32> {
-    match try!(read_i32_opt(reader)) {
+    match read_i32_opt(reader)? {
         Some(num) => Ok(num),
         None => read_err(reader, "No Number value found"),
     }
@@ -185,7 +185,7 @@ pub fn read_i32<R: Read>(reader: &mut EventReader<R>) -> Result<i32> {
 
 /// Attempts to read an optional i32.
 pub fn read_i32_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<i32>> {
-    match try!(read_string_opt(reader)) {
+    match read_string_opt(reader)? {
         Some(string) => {
             match string.parse::<i32>() {
                 Ok(num) => Ok(Some(num)),
@@ -198,7 +198,7 @@ pub fn read_i32_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<i32>>
 
 /// Attempts to read an icon.
 pub fn read_icon<R: Read>(reader: &mut EventReader<R>) -> Result<Icon> {
-    match try!(read_i32_opt(reader)) {
+    match read_i32_opt(reader)? {
         Some(num) => {
             match Icon::from_i32(num) {
                 Ok(icon) => Ok(icon),
@@ -211,7 +211,7 @@ pub fn read_icon<R: Read>(reader: &mut EventReader<R>) -> Result<Icon> {
 
 /// Attempts to read an obfuscation type.
 pub fn read_obfuscation<R: Read>(reader: &mut EventReader<R>) -> Result<Obfuscation> {
-    match try!(read_i32_opt(reader)) {
+    match read_i32_opt(reader)? {
         Some(num) => {
             match Obfuscation::from_i32(num) {
                 Ok(val) => Ok(val),
@@ -224,7 +224,7 @@ pub fn read_obfuscation<R: Read>(reader: &mut EventReader<R>) -> Result<Obfuscat
 
 /// Attempts to read a string.
 pub fn read_string<R: Read>(reader: &mut EventReader<R>) -> Result<String> {
-    match try!(read_string_opt(reader)) {
+    match read_string_opt(reader)? {
         Some(string) => Ok(string),
         None => Ok(String::new()),
     }
@@ -232,7 +232,7 @@ pub fn read_string<R: Read>(reader: &mut EventReader<R>) -> Result<String> {
 
 /// Attempts to read an optional string key
 pub fn read_string_key_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<StringKey>> {
-    match try!(read_string_opt(reader)) {
+    match read_string_opt(reader)? {
         Some(string) => Ok(Some(StringKey::from_string(&string))),
         None => Ok(None),
     }
@@ -240,7 +240,7 @@ pub fn read_string_key_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Optio
 
 /// Attempts to read an optional string.
 pub fn read_string_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<String>> {
-    let event = try!(reader.next());
+    let event = reader.next()?;
     match event {
         reader::XmlEvent::Characters(val) => Ok(Some(val)),
         reader::XmlEvent::EndElement { .. } => Ok(None),
@@ -262,11 +262,11 @@ pub fn read_string_value_opt<R: Read>(
     cipher: &mut Salsa20,
     attrs: &Vec<OwnedAttribute>,
 ) -> Result<Option<StringValue>> {
-    let pmem = try!(get_protect_in_memory_attr_value(reader, attrs));
-    let pxml = try!(get_protected_attr_value(reader, attrs));
+    let pmem = get_protect_in_memory_attr_value(reader, attrs)?;
+    let pxml = get_protected_attr_value(reader, attrs)?;
     let protected = pmem || pxml;
     if pxml {
-        match try!(read_binary_opt(reader)) {
+        match read_binary_opt(reader)? {
             Some(bytes) => {
                 let pbytes = salsa20::decrypt(cipher, &bytes);
                 match String::from_utf8(pbytes) {
@@ -277,7 +277,7 @@ pub fn read_string_value_opt<R: Read>(
             None => Ok(Some(StringValue::new("", protected))),
         }
     } else {
-        match try!(read_string_opt(reader)) {
+        match read_string_opt(reader)? {
             Some(string) => Ok(Some(StringValue::new(string, protected))),
             None => Ok(Some(StringValue::new("", protected))),
         }
@@ -286,7 +286,7 @@ pub fn read_string_value_opt<R: Read>(
 
 /// Attempts to read a UUID.
 pub fn read_uuid<R: Read>(reader: &mut EventReader<R>) -> Result<Uuid> {
-    match try!(read_uuid_opt(reader)) {
+    match read_uuid_opt(reader)? {
         Some(uuid) => Ok(uuid),
         None => read_err(reader, "No UUID value found"),
     }
@@ -294,7 +294,7 @@ pub fn read_uuid<R: Read>(reader: &mut EventReader<R>) -> Result<Uuid> {
 
 /// Attempts to read an optional UUID.
 pub fn read_uuid_opt<R: Read>(reader: &mut EventReader<R>) -> Result<Option<Uuid>> {
-    match try!(read_binary_opt(reader)) {
+    match read_binary_opt(reader)? {
         Some(bytes) => {
             match Uuid::from_bytes(&bytes) {
                 Ok(uuid) => Ok(Some(uuid)),
@@ -382,13 +382,13 @@ pub fn write_datetime_tag<W: Write>(
 
 /// Attempts to write an end tag.
 pub fn write_end_tag<W: Write>(writer: &mut EventWriter<W>) -> Result<()> {
-    try!(writer.write(writer::XmlEvent::end_element()));
+    writer.write(writer::XmlEvent::end_element())?;
     Ok(())
 }
 
 /// Attempts to write GZip compressed data.
 pub fn write_gzip<W: Write>(writer: &mut EventWriter<W>, data: &[u8]) -> Result<()> {
-    let compressed = try!(gzip::encode(data));
+    let compressed = gzip::encode(data)?;
     write_binary(writer, &compressed)
 }
 
@@ -399,20 +399,20 @@ pub fn write_i32_tag<W: Write>(writer: &mut EventWriter<W>, tag: &str, value: i3
 
 /// Attempts to write a tag that contains no data.
 pub fn write_null_tag<W: Write>(writer: &mut EventWriter<W>, tag: &str) -> Result<()> {
-    try!(write_start_tag(writer, tag));
-    try!(write_end_tag(writer));
+    write_start_tag(writer, tag)?;
+    write_end_tag(writer)?;
     Ok(())
 }
 
 /// Attempts to write a start tag.
 pub fn write_start_tag<W: Write>(writer: &mut EventWriter<W>, tag: &str) -> Result<()> {
-    try!(writer.write(writer::XmlEvent::start_element(tag)));
+    writer.write(writer::XmlEvent::start_element(tag))?;
     Ok(())
 }
 
 /// Attempts to write string data.
 pub fn write_string<W: Write>(writer: &mut EventWriter<W>, value: &String) -> Result<()> {
-    try!(writer.write(value.as_str()));
+    writer.write(value.as_str())?;
     Ok(())
 }
 
@@ -422,9 +422,9 @@ pub fn write_string_tag<W: Write>(
     tag: &str,
     value: &String,
 ) -> Result<()> {
-    try!(write_start_tag(writer, tag));
-    try!(write_string(writer, value));
-    try!(write_end_tag(writer));
+    write_start_tag(writer, tag)?;
+    write_string(writer, value)?;
+    write_end_tag(writer)?;
     Ok(())
 }
 

--- a/src/types/color.rs
+++ b/src/types/color.rs
@@ -54,9 +54,9 @@ impl Color {
         } else if !hex.starts_with("#") {
             Err(ColorError::HexStringNoHashSign)
         } else {
-            let red = try!(from_hex_string_red(hex));
-            let green = try!(from_hex_string_green(hex));
-            let blue = try!(from_hex_string_blue(hex));
+            let red = from_hex_string_red(hex)?;
+            let green = from_hex_string_green(hex)?;
+            let blue = from_hex_string_blue(hex)?;
             Ok(Color {
                 red: red,
                 green: green,

--- a/src/types/color.rs
+++ b/src/types/color.rs
@@ -133,7 +133,7 @@ impl error::Error for ColorError {
         self.msg()
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }

--- a/src/types/database.rs
+++ b/src/types/database.rs
@@ -439,12 +439,12 @@ impl Database {
         let mut reader = LogReader::new(reader);
         let mut buffer = [0u8; 4];
 
-        try!(reader.read(&mut buffer));
+        reader.read(&mut buffer)?;
         if buffer != common::DB_SIGNATURE {
             return Err(Error::InvalidDbSignature(buffer));
         }
 
-        try!(reader.read(&mut buffer));
+        reader.read(&mut buffer)?;
         if buffer == common::KDB1_SIGNATURE {
             return Err(Error::UnhandledDbType(buffer));
         } else if buffer == common::KDB2_SIGNATURE {
@@ -481,7 +481,7 @@ impl Database {
     }
 
     fn open_kdb2<R: Log + Read>(reader: &mut R, key: &CompositeKey) -> Result<Database> {
-        let (meta_data, xml_data) = try!(kdb2_reader::read(reader, key));
+        let (meta_data, xml_data) = kdb2_reader::read(reader, key)?;
         match xml_data.header_hash {
             Some(header_hash) => {
                 if meta_data.header_hash != header_hash {

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -152,7 +152,7 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Io(ref err) => Some(err),
             _ => None,

--- a/src/types/icon.rs
+++ b/src/types/icon.rs
@@ -353,7 +353,7 @@ impl error::Error for IconError {
         self.msg()
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }

--- a/src/types/key_file.rs
+++ b/src/types/key_file.rs
@@ -43,7 +43,7 @@ impl KeyFile {
     /// # }
     /// ```
     pub fn new_binary() -> Result<KeyFile> {
-        let key = try!(KeyFile::get_random_key());
+        let key = KeyFile::get_random_key()?;
         Ok(KeyFile {
             key: key,
             file_type: KeyFileType::Binary,
@@ -64,7 +64,7 @@ impl KeyFile {
     /// # }
     /// ```
     pub fn new_hex() -> Result<KeyFile> {
-        let key = try!(KeyFile::get_random_key());
+        let key = KeyFile::get_random_key()?;
         Ok(KeyFile {
             key: key,
             file_type: KeyFileType::Hex,
@@ -85,7 +85,7 @@ impl KeyFile {
     /// # }
     /// ```
     pub fn new_xml() -> Result<KeyFile> {
-        let key = try!(KeyFile::get_random_key());
+        let key = KeyFile::get_random_key()?;
         Ok(KeyFile {
             key: key,
             file_type: KeyFileType::Xml,
@@ -133,7 +133,7 @@ impl KeyFile {
     }
 
     fn get_random_key() -> Result<SecStr> {
-        let mut random = try!(RandomGen::new());
+        let mut random = RandomGen::new()?;
         let bytes = random.next_32_bytes().to_vec();
         Ok(SecStr::new(bytes))
     }

--- a/src/types/obfuscation.rs
+++ b/src/types/obfuscation.rs
@@ -88,7 +88,7 @@ impl error::Error for ObfuscationError {
         self.msg()
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }


### PR DESCRIPTION
In order to be able to read my `.kdbx` file (issue #3 and one more), I adjusted the parser to tolerate some little troubles that can happen internally.
I am not sure how serious these problems are, but I suppose that it happened over the years, during upgrades of KeepassX version. Therefore I suppose this can be the case for other users, too.

While this patch ignores these problems, it makes user aware of them by at least printing them to stderr. But maybe there is better way - perhaps, use `log` crate and report it as error or warning.
Anyway, I assume anything is better than refusing to open the KDBX file.

Also, added fixes for compiler warnings (in separate commits).