### PR TITLE
Added new attribute "parent" to Group and Entry

### DIFF
--- a/src/types/entry.rs
+++ b/src/types/entry.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use chrono::{DateTime, Utc};
-use common;
+use ::{common, GroupUuid};
 use std::collections::HashMap;
 use std::str;
 use super::association::Association;
@@ -88,6 +88,9 @@ pub struct Entry {
 
     /// The identifier of this entry.
     pub uuid: EntryUuid,
+
+    /// The parent groups GroupUUID.
+    pub parent: GroupUuid,
 }
 
 impl Entry {
@@ -218,6 +221,7 @@ impl Default for Entry {
             tags: String::new(),
             usage_count: 0,
             uuid: EntryUuid::nil(),
+            parent: GroupUuid::nil(),
         }
     }
 }

--- a/src/types/group.rs
+++ b/src/types/group.rs
@@ -75,6 +75,9 @@ pub struct Group {
 
     /// The identifier of this group.
     pub uuid: GroupUuid,
+
+    /// The parent groups GroupUUID.
+    pub parent: GroupUuid,
 }
 
 impl Group {
@@ -238,6 +241,7 @@ impl Default for Group {
             notes: String::new(),
             usage_count: 0,
             uuid: GroupUuid::nil(),
+            parent: GroupUuid::nil(),
         }
     }
 }


### PR DESCRIPTION
The parent attribute holds the GroupUUID for the parent Group of a Group or Entry. The root Group has the parent UUID with the value nil.

The current implementation is not very pretty, I'd be glad for any feedback on how to improve (I'm still quite new to rust).